### PR TITLE
Changed Automatic to Automatic (delayed start) for service

### DIFF
--- a/main.js
+++ b/main.js
@@ -51,7 +51,8 @@ if ((args.install || args.uninstall || args.stop) && is_windows) {
 		description: 'xyOps Satellite',
 		script: Path.resolve(  __dirname, 'main.js' ),
 		execPath: process.execPath,
-		scriptOptions: [ '--foreground' ]
+		scriptOptions: [ '--foreground' ],
+		delayedAutoStart: true
 	});
 	
 	if (args.install) {


### PR DESCRIPTION
Hi,

I added a little change to xysat. When I reboot a Windows server with xyOps Satellite on it, it would not autostart the service and I have to manually start it. Changing the service to Automatic  (delayed start) fixed this issue and now the service start up after a reboot. Also I think for non critical services this is a default to use on Windows.

Kind regards,

Tim